### PR TITLE
Assistant checkpoint: Enable HTML content in blog posts

### DIFF
--- a/client/src/pages/BlogPost.tsx
+++ b/client/src/pages/BlogPost.tsx
@@ -98,7 +98,7 @@ export default function BlogPost() {
             />
 
             <div className="prose max-w-none sm:prose-lg md:prose-xl break-words" data-color-mode="light">
-              <MDEditor.Markdown source={post.content} />
+              <MDEditor.Markdown source={post.content} skipHtml={false} />
             </div>
 
 


### PR DESCRIPTION
Assistant generated file changes:
- client/src/pages/BlogPost.tsx: Enable HTML rendering in blog content

---

User prompt:

kiem tra xem phan blogpost toi co the dua html vao phan noi dung duoc khong

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 7e97588b-1d78-43c9-a855-9f4e4f688151